### PR TITLE
Updated Java version enforcer rule to allow up to Java 1.7.0-update11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -318,7 +318,7 @@
                                     <version>${maven.version}</version>
                                 </requireMavenVersion>
                                 <requireJavaVersion>
-                                    <version>[1.5,1.7)</version>
+                                    <version>[1.5,1.7.0-8)</version>
                                 </requireJavaVersion>
                             </rules>
                         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -318,7 +318,7 @@
                                     <version>${maven.version}</version>
                                 </requireMavenVersion>
                                 <requireJavaVersion>
-                                    <version>[1.5,1.7.0-8)</version>
+                                    <version>[1.5,1.7.0-12)</version>
                                 </requireJavaVersion>
                             </rules>
                         </configuration>


### PR DESCRIPTION
Tested and working with the latest version of Java JDK (1.7.0-update11). Bumped enforcer rule
