### PR TITLE
Flex 4.8.0 is no longer available. Uses Flex (org.apache) 4.9.1.

### DIFF
--- a/flexmojos-testing/flexmojos-test-harness/pom.xml
+++ b/flexmojos-testing/flexmojos-test-harness/pom.xml
@@ -674,57 +674,57 @@
 
                         <!--
 
-                                Flex SDK 4.8.0.1359417
+                                Flex SDK 4.9.1.1447119
 
                         -->
 
-                        <xml>com.adobe.flex:framework:4.8.0.1359417:pom</xml>
+                        <xml>org.apache.flex:framework:4.9.1.1447119:pom</xml>
 
-                        <xml>com.adobe.flex:compiler:4.8.0.1359417:pom</xml>
-                        <xml>com.adobe.flex.compiler:asdoc:4.8.0.1359417:zip:template</xml>
-                        <xml>com.adobe.flex.framework.air:air-framework:4.8.0.1359417:pom</xml>
-                        <xml>com.adobe.flex.framework:flex-framework:4.8.0.1359417:pom</xml>
-                        <xml>com.adobe.flex.framework:framework:4.8.0.1359417:zip:configs</xml>
+                        <xml>org.apache.flex:compiler:4.9.1.1447119:pom</xml>
+                        <xml>org.apache.flex.compiler:asdoc:4.9.1.1447119:zip:template</xml>
+                        <xml>org.apache.flex.framework.air:air-framework:4.9.1.1447119:pom</xml>
+                        <xml>org.apache.flex.framework:flex-framework:4.9.1.1447119:pom</xml>
+                        <xml>org.apache.flex.framework:framework:4.9.1.1447119:zip:configs</xml>
 
-                        <xml>com.adobe.flex.framework:advancedgrids:4.8.0.1359417:rb.swc:en_US</xml>
-                        <xml>com.adobe.flex.framework:charts:4.8.0.1359417:rb.swc:en_US</xml>
-                        <xml>com.adobe.flex.framework:flash-integration:4.8.0.1359417:rb.swc:en_US</xml>
-                        <xml>com.adobe.flex.framework:framework:4.8.0.1359417:rb.swc:en_US</xml>
-                        <xml>com.adobe.flex.framework:mx:4.8.0.1359417:rb.swc:en_US</xml>
-                        <xml>com.adobe.flex.framework:rpc:4.8.0.1359417:rb.swc:en_US</xml>
-                        <xml>com.adobe.flex.framework:spark:4.8.0.1359417:rb.swc:en_US</xml>
-                        <xml>com.adobe.flex.framework.air:airframework:4.8.0.1359417:rb.swc:en_US</xml>
-                        <xml>com.adobe.flex.framework.air:airspark:4.8.0.1359417:rb.swc:en_US</xml>
+                        <xml>org.apache.flex.framework:advancedgrids:4.9.1.1447119:rb.swc:en_US</xml>
+                        <xml>org.apache.flex.framework:charts:4.9.1.1447119:rb.swc:en_US</xml>
+                        <xml>org.apache.flex.framework:flash-integration:4.9.1.1447119:rb.swc:en_US</xml>
+                        <xml>org.apache.flex.framework:framework:4.9.1.1447119:rb.swc:en_US</xml>
+                        <xml>org.apache.flex.framework:mx:4.9.1.1447119:rb.swc:en_US</xml>
+                        <xml>org.apache.flex.framework:rpc:4.9.1.1447119:rb.swc:en_US</xml>
+                        <xml>org.apache.flex.framework:spark:4.9.1.1447119:rb.swc:en_US</xml>
+                        <xml>org.apache.flex.framework.air:airframework:4.9.1.1447119:rb.swc:en_US</xml>
+                        <xml>org.apache.flex.framework.air:airspark:4.9.1.1447119:rb.swc:en_US</xml>
 
-                        <xml>com.adobe.flex.framework:advancedgrids:4.8.0.1359417:rb.swc:ja_JP</xml>
-                        <xml>com.adobe.flex.framework:charts:4.8.0.1359417:rb.swc:ja_JP</xml>
-                        <xml>com.adobe.flex.framework:flash-integration:4.8.0.1359417:rb.swc:ja_JP</xml>
-                        <xml>com.adobe.flex.framework:framework:4.8.0.1359417:rb.swc:ja_JP</xml>
-                        <xml>com.adobe.flex.framework:mx:4.8.0.1359417:rb.swc:ja_JP</xml>
-                        <xml>com.adobe.flex.framework:rpc:4.8.0.1359417:rb.swc:ja_JP</xml>
-                        <xml>com.adobe.flex.framework:spark:4.8.0.1359417:rb.swc:ja_JP</xml>
-                        <xml>com.adobe.flex.framework.air:airframework:4.8.0.1359417:rb.swc:ja_JP</xml>
-                        <xml>com.adobe.flex.framework.air:airspark:4.8.0.1359417:rb.swc:ja_JP</xml>
+                        <xml>org.apache.flex.framework:advancedgrids:4.9.1.1447119:rb.swc:ja_JP</xml>
+                        <xml>org.apache.flex.framework:charts:4.9.1.1447119:rb.swc:ja_JP</xml>
+                        <xml>org.apache.flex.framework:flash-integration:4.9.1.1447119:rb.swc:ja_JP</xml>
+                        <xml>org.apache.flex.framework:framework:4.9.1.1447119:rb.swc:ja_JP</xml>
+                        <xml>org.apache.flex.framework:mx:4.9.1.1447119:rb.swc:ja_JP</xml>
+                        <xml>org.apache.flex.framework:rpc:4.9.1.1447119:rb.swc:ja_JP</xml>
+                        <xml>org.apache.flex.framework:spark:4.9.1.1447119:rb.swc:ja_JP</xml>
+                        <xml>org.apache.flex.framework.air:airframework:4.9.1.1447119:rb.swc:ja_JP</xml>
+                        <xml>org.apache.flex.framework.air:airspark:4.9.1.1447119:rb.swc:ja_JP</xml>
 
-                        <xml>com.adobe.flex.framework:advancedgrids:4.8.0.1359417:rb.swc:pt_BR</xml>
-                        <xml>com.adobe.flex.framework:charts:4.8.0.1359417:rb.swc:pt_BR</xml>
-                        <xml>com.adobe.flex.framework:framework:4.8.0.1359417:rb.swc:pt_BR</xml>
-                        <xml>com.adobe.flex.framework:mx:4.8.0.1359417:rb.swc:pt_BR</xml>
-                        <xml>com.adobe.flex.framework:rpc:4.8.0.1359417:rb.swc:pt_BR</xml>
-                        <xml>com.adobe.flex.framework:spark:4.8.0.1359417:rb.swc:pt_BR</xml>
-                        <xml>com.adobe.flex.framework.air:airframework:4.8.0.1359417:rb.swc:pt_BR</xml>
-                        <xml>com.adobe.flex.framework.air:airspark:4.8.0.1359417:rb.swc:pt_BR</xml>
+                        <xml>org.apache.flex.framework:advancedgrids:4.9.1.1447119:rb.swc:pt_BR</xml>
+                        <xml>org.apache.flex.framework:charts:4.9.1.1447119:rb.swc:pt_BR</xml>
+                        <xml>org.apache.flex.framework:framework:4.9.1.1447119:rb.swc:pt_BR</xml>
+                        <xml>org.apache.flex.framework:mx:4.9.1.1447119:rb.swc:pt_BR</xml>
+                        <xml>org.apache.flex.framework:rpc:4.9.1.1447119:rb.swc:pt_BR</xml>
+                        <xml>org.apache.flex.framework:spark:4.9.1.1447119:rb.swc:pt_BR</xml>
+                        <xml>org.apache.flex.framework.air:airframework:4.9.1.1447119:rb.swc:pt_BR</xml>
+                        <xml>org.apache.flex.framework.air:airspark:4.9.1.1447119:rb.swc:pt_BR</xml>
 
-                        <xml>com.adobe.flex.framework:advancedgrids:4.8.0.1359417:swf</xml>
-                        <xml>com.adobe.flex.framework:charts:4.8.0.1359417:swf</xml>
-                        <xml>com.adobe.flex.framework:framework:4.8.0.1359417:swf</xml>
-                        <xml>com.adobe.flex.framework:mx:4.8.0.1359417:swf</xml>
-                        <xml>com.adobe.flex.framework:rpc:4.8.0.1359417:swf</xml>
-                        <xml>com.adobe.flex.framework:spark:4.8.0.1359417:swf</xml>
-                        <xml>com.adobe.flex.framework:spark_dmv:4.8.0.1359417:swf</xml>
-                        <xml>com.adobe.flex.framework:sparkskins:4.8.0.1359417:swf</xml>
+                        <xml>org.apache.flex.framework:advancedgrids:4.9.1.1447119:swf</xml>
+                        <xml>org.apache.flex.framework:charts:4.9.1.1447119:swf</xml>
+                        <xml>org.apache.flex.framework:framework:4.9.1.1447119:swf</xml>
+                        <xml>org.apache.flex.framework:mx:4.9.1.1447119:swf</xml>
+                        <xml>org.apache.flex.framework:rpc:4.9.1.1447119:swf</xml>
+                        <xml>org.apache.flex.framework:spark:4.9.1.1447119:swf</xml>
+                        <xml>org.apache.flex.framework:spark_dmv:4.9.1.1447119:swf</xml>
+                        <xml>org.apache.flex.framework:sparkskins:4.9.1.1447119:swf</xml>
 
-                        <xml>com.adobe.flex.framework.themes:spark:4.8.0.1359417:swc</xml>
+                        <xml>org.apache.flex.framework.themes:spark:4.9.1.1447119:swc</xml>
 
                         <!--
 


### PR DESCRIPTION
I can't manage to download anymore the Flex framework 4.8.0, unless someone give it to me, I can't get the flexmojos-test-harness complete.

I updated to use the (org.apache.flex) 4.9.1 instead. Of course this may need to support the 4.9.0 as well, but I can't find where to download it (althought I have it installed in my local repo).

Also, I don't know what to use between com.adobe.\* and org.apache.\* so this patch may not be accepted as is, but instead raise the question of what to use from now and fix if possible the flexmojos-test-harness.
