### PR TITLE
RSL hash substitution

### DIFF
--- a/flexmojos-maven-plugin/src/main/java/net/flexmojos/oss/plugin/utilities/MavenUtils.java
+++ b/flexmojos-maven-plugin/src/main/java/net/flexmojos/oss/plugin/utilities/MavenUtils.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Properties;
 import java.util.Set;
 
+import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.model.Build;
 import org.apache.maven.model.Resource;
@@ -272,6 +273,21 @@ public class MavenUtils
         sample = sample.replace( "{groupId}", artifact.getGroupId() );
         sample = sample.replace( "{artifactId}", artifact.getArtifactId() );
         sample = sample.replace( "{version}", artifact.getBaseVersion() );
+
+        if(sample.contains("{hash}"))
+        {
+            String hash = "CANT_CALCULATE_HASH";
+            try
+            {
+                byte[] artifactBytes = org.apache.commons.io.FileUtils.readFileToByteArray( artifact.getFile() );
+                hash = DigestUtils.md5Hex( artifactBytes );
+            }
+            catch (IOException ignored)
+            {
+            }
+            sample = sample.replace( "{hash}", hash );
+        }
+        
         if ( artifact.getClassifier() != null )
         {
             sample = sample.replace( "{classifier}", artifact.getClassifier() );

--- a/flexmojos-maven-plugin/src/main/java/net/flexmojos/oss/plugin/war/CopyMojo.java
+++ b/flexmojos-maven-plugin/src/main/java/net/flexmojos/oss/plugin/war/CopyMojo.java
@@ -321,10 +321,10 @@ public class CopyMojo
 
         String rslUrls = getLastRslUrls( artifactProject );
 
-        for ( Artifact rslArtifact : rslDeps )
+        for ( Artifact artifact : rslDeps )
         {
             String extension;
-            if ( RSL.equals( rslArtifact.getScope() ) )
+            if ( RSL.equals( artifact.getScope() ) )
             {
                 extension = SWF;
             }
@@ -333,12 +333,12 @@ public class CopyMojo
                 extension = SWZ;
             }
 
-            rslArtifact =
-                repositorySystem.createArtifactWithClassifier( rslArtifact.getGroupId(), rslArtifact.getArtifactId(),
-                                                               rslArtifact.getVersion(), extension, rslArtifact.getClassifier() );
+            Artifact rslArtifact =
+                repositorySystem.createArtifactWithClassifier( artifact.getGroupId(), artifact.getArtifactId(),
+                        artifact.getVersion(), extension, artifact.getClassifier() );
             rslArtifact = replaceWithResolvedArtifact( rslArtifact );
 
-            File destFile = resolveRslDestination( rslUrls, rslArtifact, extension );
+            File destFile = resolveRslDestination( rslUrls, artifact, extension );
             File sourceFile = rslArtifact.getFile();
             copy( sourceFile, destFile );
         }

--- a/flexmojos-testing/flexmojos-test-harness/projects/concept/copy-flex-resources/swf/pom.xml
+++ b/flexmojos-testing/flexmojos-test-harness/projects/concept/copy-flex-resources/swf/pom.xml
@@ -45,7 +45,7 @@
                 <version>%{flexmojos.version}</version>
                 <configuration>
                     <rslUrls>
-                        <rsl>rsls/{artifactId}-{version}.{extension}</rsl>
+                        <rsl>rsls/{artifactId}-{version}-{hash}.{extension}</rsl>
                     </rslUrls>
                     <modules>
                         <module>modules/module1.mxml</module>


### PR DESCRIPTION
Hi!

I would like to share with you my improvement to rslUrls. With this code you will be allowed to use:

``` xml
<rslUrls>
    <url>{contextRoot}/rsls/{artifactId}-{hash}.{extension}</url>
</rslUrls>
```

where hash is a md5 hash of library SWC file. It's very useful for caching RSLs, no need to worry about versions and other things - if RSL is changed, it will have different name ( for example: advancedgrids-329f05f6505656a1e8a281c838e97564.swz ).

Tested in 5.X branch (unfortunately our projects are still on 5.0-beta and 4.6.b.23130), but should works fine in 7.X because changes are backward compatible. 

Thanks!
