### PR TITLE
Added config parameter flashPlayerReturnCodesToIgnore

### DIFF
--- a/flexmojos-maven-plugin/src/main/java/net/flexmojos/oss/plugin/test/TestRunMojo.java
+++ b/flexmojos-maven-plugin/src/main/java/net/flexmojos/oss/plugin/test/TestRunMojo.java
@@ -179,6 +179,13 @@ public class TestRunMojo
      */
     private String flashPlayerCommand;
 
+    /**
+     * The flashplayer return codes to ignore
+     *
+     * @parameter default-value="" expression="${flex.flashPlayer.returnCodesToIgnore}"
+     */
+    private String flashPlayerReturnCodesToIgnore;
+
     private int numErrors;
 
     private int numFailures;
@@ -349,6 +356,7 @@ public class TestRunMojo
         testRequest.setTestPort( testPort );
         testRequest.setSwf( swf );
         testRequest.setAllowHeadlessMode( allowHeadlessMode );
+        testRequest.setFlashplayerReturnCodesToIgnore( flashPlayerReturnCodesToIgnore );
         testRequest.setTestTimeout( testTimeout );
         testRequest.setFirstConnectionTimeout( firstConnectionTimeout );
 

--- a/flexmojos-testing/flexmojos-tester/src/main/java/net/flexmojos/oss/test/TestRequest.java
+++ b/flexmojos-testing/flexmojos-tester/src/main/java/net/flexmojos/oss/test/TestRequest.java
@@ -30,6 +30,8 @@ public class TestRequest
 
     private String[] flashplayerCommand;
 
+    private String flashplayerReturnCodesToIgnore;
+
     private File swf;
 
     private File swfDescriptor;
@@ -60,6 +62,10 @@ public class TestRequest
     public String[] getFlashplayerCommand()
     {
         return this.flashplayerCommand;
+    }
+
+    public String getFlashplayerReturnCodesToIgnore() {
+        return flashplayerReturnCodesToIgnore;
     }
 
     public File getSwf()
@@ -110,6 +116,10 @@ public class TestRequest
     public void setFlashplayerCommand( String... flashplayerCommand )
     {
         this.flashplayerCommand = flashplayerCommand;
+    }
+
+    public void setFlashplayerReturnCodesToIgnore(String flashplayerReturnCodesToIgnore) {
+        this.flashplayerReturnCodesToIgnore = flashplayerReturnCodesToIgnore;
     }
 
     public void setSwf( File swf )

--- a/flexmojos-testing/flexmojos-tester/src/main/java/net/flexmojos/oss/test/launcher/AsVmLauncher.java
+++ b/flexmojos-testing/flexmojos-tester/src/main/java/net/flexmojos/oss/test/launcher/AsVmLauncher.java
@@ -73,6 +73,8 @@ public class AsVmLauncher
 
     private StringBuffer consoleLog = new StringBuffer();
 
+    private String flashplayerReturnCodesToIgnore;
+
     private File log;
 
     private Process process;
@@ -146,6 +148,18 @@ public class AsVmLauncher
 
         getLogger().debug( "[LAUNCHER] " + errorMessage );
 
+        if (flashplayerReturnCodesToIgnore != null &&
+                Arrays.asList(flashplayerReturnCodesToIgnore.split(",")).contains("" + returnCode))
+        {
+            getLogger().warn( "Flashplayer quit with unexpected return code " + returnCode +
+                              " but the code was in the flashPlayerReturnCodesToIgnore, so continuing.");
+            status = ThreadStatus.DONE;
+            return;
+        } else {
+            getLogger().warn( "Flashplayer quit with unexpected return code " + returnCode +
+                              ", to ignore this error, add flashPlayerReturnCodesToIgnore to your configuration" +
+                              " with a comma separated list of return codes to ignore.");
+        }
         status = ThreadStatus.ERROR;
         error = new Error( errorMessage );
     }
@@ -276,6 +290,8 @@ public class AsVmLauncher
         }
 
         allowHeadlessMode = request.getAllowHeadlessMode();
+
+        flashplayerReturnCodesToIgnore = request.getFlashplayerReturnCodesToIgnore();
 
         if ( targetFile == null )
         {

--- a/flexmojos-testing/flexmojos-tester/src/main/java/net/flexmojos/oss/test/launcher/AsVmLauncher.java
+++ b/flexmojos-testing/flexmojos-tester/src/main/java/net/flexmojos/oss/test/launcher/AsVmLauncher.java
@@ -148,17 +148,18 @@ public class AsVmLauncher
 
         getLogger().debug( "[LAUNCHER] " + errorMessage );
 
-        if (flashplayerReturnCodesToIgnore != null &&
-                Arrays.asList(flashplayerReturnCodesToIgnore.split(",")).contains("" + returnCode))
-        {
-            getLogger().warn( "Flashplayer quit with unexpected return code " + returnCode +
-                              " but the code was in the flashPlayerReturnCodesToIgnore, so continuing.");
-            status = ThreadStatus.DONE;
-            return;
-        } else {
-            getLogger().warn( "Flashplayer quit with unexpected return code " + returnCode +
-                              ", to ignore this error, add flashPlayerReturnCodesToIgnore to your configuration" +
-                              " with a comma separated list of return codes to ignore.");
+        if ( OSUtils.isLinux() ) {
+            if ( flashplayerReturnCodesToIgnore != null &&
+                    Arrays.asList(flashplayerReturnCodesToIgnore.split(",")).contains("" + returnCode) ) {
+                getLogger().warn("Flashplayer quit with unexpected return code " + returnCode +
+                        " but the code was in the flashPlayerReturnCodesToIgnore, so continuing.");
+                status = ThreadStatus.DONE;
+                return;
+            } else {
+                getLogger().warn("Flashplayer quit with unexpected return code " + returnCode +
+                        ". To ignore this error, add flashPlayerReturnCodesToIgnore to your configuration" +
+                        " with a comma separated list of return codes to ignore.");
+            }
         }
         status = ThreadStatus.ERROR;
         error = new Error( errorMessage );


### PR DESCRIPTION
to be able to ignore return codes from the flashplayer. This is meant to solve problems in some Linux environments where the flashplayer crashes on exit after all the tests has been run.
