### PR TITLE
If the build POM does not have a reference to the flex framework, then

### DIFF
--- a/flexmojos-maven-plugin/src/main/java/net/flexmojos/oss/plugin/AbstractMavenMojo.java
+++ b/flexmojos-maven-plugin/src/main/java/net/flexmojos/oss/plugin/AbstractMavenMojo.java
@@ -483,7 +483,10 @@ public abstract class AbstractMavenMojo
         if(frameworkArtifact != null) {
             return frameworkArtifact.getGroupId() + ".framework";
         }
-        return null;
+
+        // This is a sensible default, and is what is always returned currently
+        // from getFrameworkArtifact anyway.
+        return "org.apache.flex.framework";
     }
 
     public String getCompilerVersion()
@@ -501,7 +504,10 @@ public abstract class AbstractMavenMojo
         if(frameworkArtifact != null) {
             return frameworkArtifact.getVersion();
         }
-        return null;
+
+        // Missing. Try framework version
+
+        return getFrameworkVersion();
     }
 
     public Set<Artifact> getDependencies()

--- a/flexmojos-maven-plugin/src/main/java/net/flexmojos/oss/plugin/compiler/AbstractFlexCompilerMojo.java
+++ b/flexmojos-maven-plugin/src/main/java/net/flexmojos/oss/plugin/compiler/AbstractFlexCompilerMojo.java
@@ -2498,7 +2498,8 @@ public abstract class AbstractFlexCompilerMojo<CFG, C extends AbstractFlexCompil
 
         if ( dir == null )
         {
-            return this.namespaces;
+            getLog().error("Could not find framework. Namespaces not included in configuration; errors in the build may occur.");
+            return namespaces.toArray( new INamespace[namespaces.size()] );
         }
 
         Reader cfg = null;


### PR DESCRIPTION
it cannot find the framework ZIP, and consequently the build does not
include the correct namespaces section.

This is the case when specifying the dependencies directly rather than
through a frameowrk POM dependency (which has problems in maven because
of the fact that it does not understand the custom scopes)

By using some defaults and looking at other dependencies instead, we can
fix this.

Signed-off-by: Nigel Magnay nigel.magnay@gmail.com
