### PR TITLE
Make possible to run flexmojos on maven 3.3.9

### DIFF
--- a/flexmojos-archetypes/flexmojos-archetypes-application/pom.xml
+++ b/flexmojos-archetypes/flexmojos-archetypes-application/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>net.flexmojos.oss</groupId>
         <artifactId>flexmojos-archetypes</artifactId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>7.1.1</version>
     </parent>
 
     <artifactId>flexmojos-archetypes-application</artifactId>

--- a/flexmojos-archetypes/flexmojos-archetypes-library/pom.xml
+++ b/flexmojos-archetypes/flexmojos-archetypes-library/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>net.flexmojos.oss</groupId>
         <artifactId>flexmojos-archetypes</artifactId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>7.1.1</version>
     </parent>
 
     <artifactId>flexmojos-archetypes-library</artifactId>

--- a/flexmojos-archetypes/flexmojos-archetypes-mobile-application/pom.xml
+++ b/flexmojos-archetypes/flexmojos-archetypes-mobile-application/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>net.flexmojos.oss</groupId>
         <artifactId>flexmojos-archetypes</artifactId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>7.1.1</version>
     </parent>
 
     <artifactId>flexmojos-archetypes-mobile-application</artifactId>

--- a/flexmojos-archetypes/flexmojos-archetypes-modular-webapp/pom.xml
+++ b/flexmojos-archetypes/flexmojos-archetypes-modular-webapp/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <artifactId>flexmojos-archetypes</artifactId>
         <groupId>net.flexmojos.oss</groupId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>7.1.1</version>
     </parent>
 
     <artifactId>flexmojos-archetypes-modular-webapp</artifactId>

--- a/flexmojos-archetypes/pom.xml
+++ b/flexmojos-archetypes/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>net.flexmojos.oss</groupId>
     <artifactId>flexmojos-parent</artifactId>
-    <version>7.2.0-SNAPSHOT</version>
+    <version>7.1.1</version>
   </parent>
 
   <artifactId>flexmojos-archetypes</artifactId>

--- a/flexmojos-generator/flexmojos-generator-api/pom.xml
+++ b/flexmojos-generator/flexmojos-generator-api/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>net.flexmojos.oss</groupId>
         <artifactId>flexmojos-generator</artifactId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>7.1.1</version>
     </parent>
 
     <artifactId>flexmojos-generator-api</artifactId>

--- a/flexmojos-generator/flexmojos-generator-constraints/pom.xml
+++ b/flexmojos-generator/flexmojos-generator-constraints/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>net.flexmojos.oss</groupId>
         <artifactId>flexmojos-generator</artifactId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>7.1.1</version>
     </parent>
 
     <artifactId>flexmojos-generator-constraints</artifactId>

--- a/flexmojos-generator/flexmojos-generator-graniteds-2.0.0/pom.xml
+++ b/flexmojos-generator/flexmojos-generator-graniteds-2.0.0/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>net.flexmojos.oss</groupId>
     <artifactId>flexmojos-generator</artifactId>
-    <version>7.2.0-SNAPSHOT</version>
+    <version>7.1.1</version>
   </parent>
 
   <artifactId>flexmojos-generator-graniteds-2.0.0</artifactId>

--- a/flexmojos-generator/flexmojos-generator-graniteds-2.1.0/pom.xml
+++ b/flexmojos-generator/flexmojos-generator-graniteds-2.1.0/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>net.flexmojos.oss</groupId>
     <artifactId>flexmojos-generator</artifactId>
-    <version>7.2.0-SNAPSHOT</version>
+    <version>7.1.1</version>
   </parent>
 
   <artifactId>flexmojos-generator-graniteds-2.1.0</artifactId>

--- a/flexmojos-generator/flexmojos-generator-graniteds-2.2.0/pom.xml
+++ b/flexmojos-generator/flexmojos-generator-graniteds-2.2.0/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>net.flexmojos.oss</groupId>
     <artifactId>flexmojos-generator</artifactId>
-    <version>7.2.0-SNAPSHOT</version>
+    <version>7.1.1</version>
   </parent>
 
   <artifactId>flexmojos-generator-graniteds-2.2.0</artifactId>

--- a/flexmojos-generator/flexmojos-generator-graniteds-2.3.0/pom.xml
+++ b/flexmojos-generator/flexmojos-generator-graniteds-2.3.0/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>net.flexmojos.oss</groupId>
     <artifactId>flexmojos-generator</artifactId>
-    <version>7.2.0-SNAPSHOT</version>
+    <version>7.1.1</version>
   </parent>
 
   <artifactId>flexmojos-generator-graniteds-2.3.0</artifactId>

--- a/flexmojos-generator/flexmojos-generator-graniteds-2.3.2/pom.xml
+++ b/flexmojos-generator/flexmojos-generator-graniteds-2.3.2/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>net.flexmojos.oss</groupId>
         <artifactId>flexmojos-generator</artifactId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>7.1.1</version>
     </parent>
 
     <artifactId>flexmojos-generator-graniteds-2.3.2</artifactId>

--- a/flexmojos-generator/flexmojos-generator-graniteds-3.1.0/pom.xml
+++ b/flexmojos-generator/flexmojos-generator-graniteds-3.1.0/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>net.flexmojos.oss</groupId>
         <artifactId>flexmojos-generator</artifactId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>7.1.1</version>
     </parent>
 
     <artifactId>flexmojos-generator-graniteds-3.1.0</artifactId>

--- a/flexmojos-generator/flexmojos-generator-internal-compiler-iface/pom.xml
+++ b/flexmojos-generator/flexmojos-generator-internal-compiler-iface/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>net.flexmojos.oss</groupId>
         <artifactId>flexmojos-generator</artifactId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>7.1.1</version>
     </parent>
 
     <artifactId>flexmojos-generator-internal-compiler-iface</artifactId>

--- a/flexmojos-generator/flexmojos-generator-internal-threadlocal/pom.xml
+++ b/flexmojos-generator/flexmojos-generator-internal-threadlocal/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>net.flexmojos.oss</groupId>
         <artifactId>flexmojos-generator</artifactId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>7.1.1</version>
     </parent>
 
     <artifactId>flexmojos-generator-internal-threadlocal</artifactId>

--- a/flexmojos-generator/flexmojos-generator-mojo/pom.xml
+++ b/flexmojos-generator/flexmojos-generator-mojo/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>net.flexmojos.oss</groupId>
         <artifactId>flexmojos-generator</artifactId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>7.1.1</version>
     </parent>
 
     <artifactId>flexmojos-generator-mojo</artifactId>

--- a/flexmojos-generator/pom.xml
+++ b/flexmojos-generator/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>flexmojos-parent</artifactId>
         <groupId>net.flexmojos.oss</groupId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>7.1.1</version>
     </parent>
 
     <artifactId>flexmojos-generator</artifactId>

--- a/flexmojos-maven-plugin/pom.xml
+++ b/flexmojos-maven-plugin/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>net.flexmojos.oss</groupId>
         <artifactId>flexmojos-parent</artifactId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>7.1.1</version>
     </parent>
 
     <artifactId>flexmojos-maven-plugin</artifactId>
@@ -35,7 +35,7 @@
     <description>With this maven plugin Flex3/AS3 sources can be compiled into a SWC or SWF package.</description>
 
     <prerequisites>
-        <maven>${maven.version}</maven>
+        <maven>${maven.min.runtime.version}</maven>
     </prerequisites>
 
     <developers>

--- a/flexmojos-maven-plugin/src/main/java/net/flexmojos/oss/plugin/lifecyclemapping/AbstractActionScriptLifecycleMapping.java
+++ b/flexmojos-maven-plugin/src/main/java/net/flexmojos/oss/plugin/lifecyclemapping/AbstractActionScriptLifecycleMapping.java
@@ -17,11 +17,14 @@
  */
 package net.flexmojos.oss.plugin.lifecyclemapping;
 
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 
 import org.apache.maven.lifecycle.mapping.Lifecycle;
+import org.apache.maven.lifecycle.mapping.LifecyclePhase;
 
 public abstract class AbstractActionScriptLifecycleMapping
 {
@@ -56,10 +59,29 @@ public abstract class AbstractActionScriptLifecycleMapping
         }
         phases.put( "install", "org.apache.maven.plugins:maven-install-plugin:install" );
         phases.put( "deploy", "org.apache.maven.plugins:maven-deploy-plugin:deploy" );
-        lifecycle.setPhases( phases );
+        setPhases(lifecycle, phases );
 
         lifecycleMap.put( "default", lifecycle );
         return lifecycleMap;
+    }
+
+    private void setPhases(Lifecycle lifecycle, Map<String, String> phases)
+    {
+      try
+      {
+        Class.forName("org.apache.maven.lifecycle.mapping.LifecyclePhase");
+        
+        Map<String, LifecyclePhase> lifecyclePhases = new HashMap<String, LifecyclePhase>();
+        for (Entry<String, String> entry : phases.entrySet())
+        {
+          lifecyclePhases.put(entry.getKey(), new LifecyclePhase(entry.getValue()));
+        }
+        lifecycle.setLifecyclePhases(lifecyclePhases);
+      }
+      catch (ClassNotFoundException e)
+      {
+        lifecycle.setPhases((Map) phases);
+      }
     }
 
     protected String getPackage()

--- a/flexmojos-maven-plugin/src/main/java/net/flexmojos/oss/plugin/lifecyclemapping/AbstractActionScriptLifecycleMapping.java
+++ b/flexmojos-maven-plugin/src/main/java/net/flexmojos/oss/plugin/lifecyclemapping/AbstractActionScriptLifecycleMapping.java
@@ -70,7 +70,7 @@ public abstract class AbstractActionScriptLifecycleMapping
       try
       {
         Class.forName("org.apache.maven.lifecycle.mapping.LifecyclePhase");
-        
+
         Map<String, LifecyclePhase> lifecyclePhases = new HashMap<String, LifecyclePhase>();
         for (Entry<String, String> entry : phases.entrySet())
         {

--- a/flexmojos-sandbox/flexmojos-configurator/pom.xml
+++ b/flexmojos-sandbox/flexmojos-configurator/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>net.flexmojos.oss</groupId>
         <artifactId>flexmojos-sandbox</artifactId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>7.1.1</version>
     </parent>
 
     <artifactId>flexmojos-configurator</artifactId>

--- a/flexmojos-sandbox/flexmojos-coverage-reporter/pom.xml
+++ b/flexmojos-sandbox/flexmojos-coverage-reporter/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>net.flexmojos.oss</groupId>
         <artifactId>flexmojos-sandbox</artifactId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>7.1.1</version>
     </parent>
 
     <artifactId>flexmojos-coverage-reporter</artifactId>

--- a/flexmojos-sandbox/flexmojos-flex-compiler/pom.xml
+++ b/flexmojos-sandbox/flexmojos-flex-compiler/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>net.flexmojos.oss</groupId>
         <artifactId>flexmojos-sandbox</artifactId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>7.1.1</version>
     </parent>
 
     <artifactId>flexmojos-flex-compiler</artifactId>

--- a/flexmojos-sandbox/flexmojos-sample-configurator/pom.xml
+++ b/flexmojos-sandbox/flexmojos-sample-configurator/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>net.flexmojos.oss</groupId>
     <artifactId>flexmojos-sandbox</artifactId>
-    <version>7.2.0-SNAPSHOT</version>
+    <version>7.1.1</version>
   </parent>
 
   <artifactId>flexmojos-sample-configurator</artifactId>

--- a/flexmojos-sandbox/pom.xml
+++ b/flexmojos-sandbox/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>net.flexmojos.oss</groupId>
         <artifactId>flexmojos-parent</artifactId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>7.1.1</version>
     </parent>
 
     <artifactId>flexmojos-sandbox</artifactId>

--- a/flexmojos-testing/flexmojos-test-harness/pom.xml
+++ b/flexmojos-testing/flexmojos-test-harness/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>net.flexmojos.oss</groupId>
         <artifactId>flexmojos-testing</artifactId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>7.1.1</version>
     </parent>
 
     <artifactId>flexmojos-test-harness</artifactId>

--- a/flexmojos-testing/flexmojos-tester/pom.xml
+++ b/flexmojos-testing/flexmojos-tester/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>net.flexmojos.oss</groupId>
         <artifactId>flexmojos-testing</artifactId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>7.1.1</version>
     </parent>
 
     <artifactId>flexmojos-tester</artifactId>

--- a/flexmojos-testing/flexmojos-unittest/flexmojos-test-coverage/pom.xml
+++ b/flexmojos-testing/flexmojos-unittest/flexmojos-test-coverage/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>net.flexmojos.oss</groupId>
         <artifactId>flexmojos-unittest</artifactId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>7.1.1</version>
     </parent>
 
     <artifactId>flexmojos-test-coverage</artifactId>

--- a/flexmojos-testing/flexmojos-unittest/flexmojos-unittest-advancedflex/pom.xml
+++ b/flexmojos-testing/flexmojos-unittest/flexmojos-unittest-advancedflex/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>net.flexmojos.oss</groupId>
         <artifactId>flexmojos-unittest</artifactId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>7.1.1</version>
     </parent>
 
     <artifactId>flexmojos-unittest-advancedflex</artifactId>

--- a/flexmojos-testing/flexmojos-unittest/flexmojos-unittest-asunit/pom.xml
+++ b/flexmojos-testing/flexmojos-unittest/flexmojos-unittest-asunit/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>net.flexmojos.oss</groupId>
         <artifactId>flexmojos-unittest</artifactId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>7.1.1</version>
     </parent>
 
     <artifactId>flexmojos-unittest-asunit</artifactId>

--- a/flexmojos-testing/flexmojos-unittest/flexmojos-unittest-flexunit/pom.xml
+++ b/flexmojos-testing/flexmojos-unittest/flexmojos-unittest-flexunit/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>net.flexmojos.oss</groupId>
         <artifactId>flexmojos-unittest</artifactId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>7.1.1</version>
     </parent>
 
     <artifactId>flexmojos-unittest-flexunit</artifactId>

--- a/flexmojos-testing/flexmojos-unittest/flexmojos-unittest-flexunit4/pom.xml
+++ b/flexmojos-testing/flexmojos-unittest/flexmojos-unittest-flexunit4/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>net.flexmojos.oss</groupId>
         <artifactId>flexmojos-unittest</artifactId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>7.1.1</version>
     </parent>
 
     <artifactId>flexmojos-unittest-flexunit4</artifactId>

--- a/flexmojos-testing/flexmojos-unittest/flexmojos-unittest-fluint/pom.xml
+++ b/flexmojos-testing/flexmojos-unittest/flexmojos-unittest-fluint/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>net.flexmojos.oss</groupId>
         <artifactId>flexmojos-unittest</artifactId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>7.1.1</version>
     </parent>
 
     <artifactId>flexmojos-unittest-fluint</artifactId>

--- a/flexmojos-testing/flexmojos-unittest/flexmojos-unittest-funit/pom.xml
+++ b/flexmojos-testing/flexmojos-unittest/flexmojos-unittest-funit/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>net.flexmojos.oss</groupId>
         <artifactId>flexmojos-unittest</artifactId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>7.1.1</version>
     </parent>
 
     <artifactId>flexmojos-unittest-funit</artifactId>

--- a/flexmojos-testing/flexmojos-unittest/flexmojos-unittest-support/pom.xml
+++ b/flexmojos-testing/flexmojos-unittest/flexmojos-unittest-support/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>net.flexmojos.oss</groupId>
         <artifactId>flexmojos-unittest</artifactId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>7.1.1</version>
     </parent>
 
     <artifactId>flexmojos-unittest-support</artifactId>

--- a/flexmojos-testing/flexmojos-unittest/pom.xml
+++ b/flexmojos-testing/flexmojos-unittest/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>net.flexmojos.oss</groupId>
         <artifactId>flexmojos-testing</artifactId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>7.1.1</version>
     </parent>
 
     <artifactId>flexmojos-unittest</artifactId>

--- a/flexmojos-testing/pom.xml
+++ b/flexmojos-testing/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>net.flexmojos.oss</groupId>
         <artifactId>flexmojos-parent</artifactId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>7.1.1</version>
     </parent>
 
     <artifactId>flexmojos-testing</artifactId>

--- a/flexmojos-util/pom.xml
+++ b/flexmojos-util/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>net.flexmojos.oss</groupId>
         <artifactId>flexmojos-parent</artifactId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>7.1.1</version>
     </parent>
 
     <artifactId>flexmojos-util</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>net.flexmojos.oss</groupId>
     <artifactId>flexmojos-parent</artifactId>
-    <version>7.2.0-SNAPSHOT</version>
+    <version>7.1.1</version>
     <packaging>pom</packaging>
 
     <name>Flexmojos Parent</name>
@@ -37,7 +37,7 @@
     <inceptionYear>2008</inceptionYear>
 
     <prerequisites>
-        <maven>${maven.version}</maven>
+        <maven>${maven.min.runtime.version}</maven>
     </prerequisites>
 
     <distributionManagement>
@@ -78,6 +78,7 @@
         <flash.version>18.0</flash.version>
 
         <commons_io.version>2.4</commons_io.version>
+        <maven.min.runtime.version>3.1.1</maven.min.runtime.version>
         <maven.version>3.3.9</maven.version>
         <maven-site-plugin.version>3.4</maven-site-plugin.version>
         <sisu.version>3.2.4</sisu.version>
@@ -91,7 +92,7 @@
                 <plugin>
                     <groupId>net.flexmojos.oss</groupId>
                     <artifactId>flexmojos-maven-plugin</artifactId>
-                    <version>7.2.0-SNAPSHOT</version>
+                    <version>7.1.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
@@ -162,6 +163,7 @@
                     <version>1.5</version>
                     <executions>
                         <execution>
+						<phase>process-classes</phase>
                             <goals>
                                 <goal>inherit</goal>
                             </goals>
@@ -194,7 +196,10 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>2.9.1</version>
+                    <version>2.10.4</version>
+					<configuration>
+						<additionalparam>-Xdoclint:none</additionalparam>
+					</configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -298,7 +303,7 @@
                                     </excludes>
                                 </bannedDependencies>
                                 <requireMavenVersion>
-                                    <version>${maven.version}</version>
+                                    <version>${maven.min.runtime.version}</version>
                                 </requireMavenVersion>
                                 <requireJavaVersion>
                                     <version>[1.5,)</version>
@@ -307,15 +312,6 @@
                         </configuration>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.3</version>
-                <configuration>
-                    <serverId>ossrh</serverId>
-                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                </configuration>
             </plugin>
         </plugins>
     </build>
@@ -457,6 +453,7 @@
                     <plugin>
                         <artifactId>maven-deploy-plugin</artifactId>
                         <configuration>
+						<skip>false</skip>
                             <updateReleaseInfo>true</updateReleaseInfo>
                         </configuration>
                     </plugin>
@@ -605,7 +602,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.9</version>
+                <version>2.10.4</version>
+					<configuration>
+						<additionalparam>-Xdoclint:none</additionalparam>
+					</configuration>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
         <flash.version>18.0</flash.version>
 
         <commons_io.version>2.4</commons_io.version>
-        <maven.version>3.1.1</maven.version>
+        <maven.version>3.3.9</maven.version>
         <maven-site-plugin.version>3.4</maven-site-plugin.version>
         <sisu.version>3.2.4</sisu.version>
         <plexus.version>1.5.5</plexus.version>


### PR DESCRIPTION
Flexmojos don't work at all on maven 3.3.9 (so, won't work on travis CI)

````
[INFO] Scanning for projects...
[ERROR] Internal error: java.lang.ClassCastException: java.lang.String cannot be cast to org.apache.maven.lifecycle.mapping.LifecyclePhase -> [Help 1]
org.apache.maven.InternalErrorException: Internal error: java.lang.ClassCastException: java.lang.String cannot be cast to org.apache.maven.lifecycle.mapping.LifecyclePhase
        at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:121)
        at org.apache.maven.cli.MavenCli.execute(MavenCli.java:863)
        at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:288)
        at org.apache.maven.cli.MavenCli.main(MavenCli.java:199)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:289)
        at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:229)
        at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:415)
        at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:356)
Caused by: java.lang.ClassCastException: java.lang.String cannot be cast to org.apache.maven.lifecycle.mapping.LifecyclePhase
        at org.apache.maven.lifecycle.internal.DefaultLifecyclePluginAnalyzer.getPluginsBoundByDefaultToAllLifecycles(DefaultLifecyclePluginAnalyzer.java:119)
        at org.apache.maven.model.plugin.DefaultLifecycleBindingsInjector.injectLifecycleBindings(DefaultLifecycleBindingsInjector.java:64)
        at org.apache.maven.model.building.DefaultModelBuilder.build(DefaultModelBuilder.java:451)
        at org.apache.maven.model.building.DefaultModelBuilder.build(DefaultModelBuilder.java:421)
        at org.apache.maven.project.DefaultProjectBuilder.build(DefaultProjectBuilder.java:620)
        at org.apache.maven.project.DefaultProjectBuilder.build(DefaultProjectBuilder.java:626)
        at org.apache.maven.project.DefaultProjectBuilder.build(DefaultProjectBuilder.java:411)
        at org.apache.maven.graph.DefaultGraphBuilder.collectProjects(DefaultGraphBuilder.java:419)
        at org.apache.maven.graph.DefaultGraphBuilder.getProjectsForMavenReactor(DefaultGraphBuilder.java:410)
        at org.apache.maven.graph.DefaultGraphBuilder.build(DefaultGraphBuilder.java:83)
        at org.apache.maven.DefaultMaven.buildGraph(DefaultMaven.java:491)
        at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:219)
        at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:193)
        at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:106)
        ... 11 more
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/InternalErrorException

````