### PR TITLE
Add support for specifying the timestampServer to ADT

### DIFF
--- a/flexmojos-maven-plugin/src/main/java/net/flexmojos/oss/plugin/air/PackageAirMojo.java
+++ b/flexmojos-maven-plugin/src/main/java/net/flexmojos/oss/plugin/air/PackageAirMojo.java
@@ -128,6 +128,13 @@ public class PackageAirMojo
     private String storetype;
 
     /**
+     * The timing server to use for package signing.
+     *
+     * @parameter
+     */
+    private String timestampServerUrl;
+
+    /**
      * Path to the provisioning profile document.
      *
      * @parameter
@@ -222,6 +229,7 @@ public class PackageAirMojo
         packagingRequest.setStorefile(storefile);
         packagingRequest.setStoretype(storetype);
         packagingRequest.setStorepass(storepass);
+        packagingRequest.setTimeStampServerUrl(timestampServerUrl);
 
         packagingRequest.setIosProvisioningProfile(iosProvisioningProfile);
         packagingRequest.setIosPlatformSdk(iosPlatformSdk);

--- a/flexmojos-maven-plugin/src/main/java/net/flexmojos/oss/plugin/air/packager/AirPackager.java
+++ b/flexmojos-maven-plugin/src/main/java/net/flexmojos/oss/plugin/air/packager/AirPackager.java
@@ -60,14 +60,15 @@ public class AirPackager extends BasePackager {
         adtArgs.add(request.getStorepass());
         adtArgs.add("-keypass");
         adtArgs.add(request.getStorepass());
-        adtArgs.add(request.getOutputFile().getAbsolutePath());
-        adtArgs.add(request.getDescriptorFile().getAbsolutePath());
-        adtArgs.add(request.getInputFile().getName());
         final Optional<String> timeStampServerUrl = request.getTimeStampServerUrl();
         if (timeStampServerUrl.isPresent()) {
             adtArgs.add("-tsa");
             adtArgs.add(timeStampServerUrl.get());
         }
+        adtArgs.add(request.getOutputFile().getAbsolutePath());
+        adtArgs.add(request.getDescriptorFile().getAbsolutePath());
+        adtArgs.add(request.getInputFile().getName());
+
         runAdt(adtArgs);
 
         if (!outputFile.exists()) {

--- a/flexmojos-maven-plugin/src/main/java/net/flexmojos/oss/plugin/air/packager/AirPackager.java
+++ b/flexmojos-maven-plugin/src/main/java/net/flexmojos/oss/plugin/air/packager/AirPackager.java
@@ -22,6 +22,7 @@ import org.codehaus.plexus.component.annotations.Component;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 @Component(role = net.flexmojos.oss.plugin.air.packager.Packager.class, hint = "air")
 public class AirPackager extends BasePackager {
@@ -46,7 +47,7 @@ public class AirPackager extends BasePackager {
     @Override
     public File execute() throws PackagingException {
         File outputFile = new File(request.getBuildDir(), request.getFinalName() +
-                ((request.getClassifier() != null) ? "-" + request.getClassifier() : "")  +".air");
+                ((request.getClassifier() != null) ? "-" + request.getClassifier() : "") + ".air");
         request.setOutputFile(outputFile);
 
         List<String> adtArgs = new ArrayList<String>();
@@ -62,9 +63,14 @@ public class AirPackager extends BasePackager {
         adtArgs.add(request.getOutputFile().getAbsolutePath());
         adtArgs.add(request.getDescriptorFile().getAbsolutePath());
         adtArgs.add(request.getInputFile().getName());
+        final Optional<String> timeStampServerUrl = request.getTimeStampServerUrl();
+        if (timeStampServerUrl.isPresent()) {
+            adtArgs.add("-tsa");
+            adtArgs.add(timeStampServerUrl.get());
+        }
         runAdt(adtArgs);
 
-        if(!outputFile.exists()) {
+        if (!outputFile.exists()) {
             throw new PackagingException("Output file does not exist " + outputFile.getAbsolutePath());
         }
 

--- a/flexmojos-maven-plugin/src/main/java/net/flexmojos/oss/plugin/air/packager/PackagingRequest.java
+++ b/flexmojos-maven-plugin/src/main/java/net/flexmojos/oss/plugin/air/packager/PackagingRequest.java
@@ -49,6 +49,8 @@ public class PackagingRequest {
 
     protected Map<String, List<String>> includedFiles;
 
+    protected Optional<String> timeStampServerUrl;
+
     public Log getLog() {
         return log;
     }
@@ -219,5 +221,13 @@ public class PackagingRequest {
 
     public Map<String, List<String>> getIncludedFiles() {
         return includedFiles;
+    }
+
+    public void setTimeStampServerUrl(String timeStampServerUrl) {
+        this.timeStampServerUrl = Optional.ofNullable(timeStampServerUrl);
+    }
+
+    public Optional<String> getTimeStampServerUrl() {
+        return timeStampServerUrl;
     }
 }

--- a/flexmojos-sandbox/flexmojos-tester/pom.xml
+++ b/flexmojos-sandbox/flexmojos-tester/pom.xml
@@ -22,9 +22,9 @@
 
     <parent>
         <groupId>net.flexmojos.oss</groupId>
-        <artifactId>flexmojos-testing</artifactId>
+        <artifactId>flexmojos-sandbox</artifactId>
         <version>7.2.0-SNAPSHOT</version>
-        <relativePath>../../flexmojos-testing/pom.xml</relativePath>
+        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>flexmojos-tester</artifactId>

--- a/flexmojos-sandbox/flexmojos-tester/pom.xml
+++ b/flexmojos-sandbox/flexmojos-tester/pom.xml
@@ -24,6 +24,7 @@
         <groupId>net.flexmojos.oss</groupId>
         <artifactId>flexmojos-testing</artifactId>
         <version>7.2.0-SNAPSHOT</version>
+        <relativePath>../../flexmojos-testing/pom.xml</relativePath>
     </parent>
 
     <artifactId>flexmojos-tester</artifactId>

--- a/flexmojos-sandbox/flexmojos-threadlocaltoolkit-wrapper/pom.xml
+++ b/flexmojos-sandbox/flexmojos-threadlocaltoolkit-wrapper/pom.xml
@@ -1,5 +1,5 @@
-<!-- Flexmojos is a set of maven goals to allow maven users to compile, optimize and test Flex SWF, Flex SWC, Air SWF and Air SWC. Copyright (C) 2008-2012 Marvin Froeder <marvin@flexmojos.net> This program is free software: you can redistribute it and/or modify 
-  it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; 
+<!-- Flexmojos is a set of maven goals to allow maven users to compile, optimize and test Flex SWF, Flex SWC, Air SWF and Air SWC. Copyright (C) 2008-2012 Marvin Froeder <marvin@flexmojos.net> This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
   without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with this program. If not, see <http://www.gnu.org/licenses />. -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.flexmojos.oss</groupId>
         <artifactId>flexmojos-sandbox</artifactId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>7.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>flexmojos-threadlocaltoolkit-wrapper</artifactId>

--- a/flexmojos-super-poms/pom.xml
+++ b/flexmojos-super-poms/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>net.flexmojos.oss</groupId>
         <artifactId>flexmojos-parent</artifactId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>7.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>flexmojos-super-poms</artifactId>

--- a/flexmojos-testing/flexmojos-unittest/pom.xml
+++ b/flexmojos-testing/flexmojos-unittest/pom.xml
@@ -24,6 +24,7 @@
         <groupId>net.flexmojos.oss</groupId>
         <artifactId>flexmojos-testing</artifactId>
         <version>7.2.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>flexmojos-unittest</artifactId>

--- a/flexmojos-testing/pom.xml
+++ b/flexmojos-testing/pom.xml
@@ -25,6 +25,7 @@
         <groupId>net.flexmojos.oss</groupId>
         <artifactId>flexmojos-parent</artifactId>
         <version>7.2.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>flexmojos-testing</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -42,25 +42,47 @@
 
     <distributionManagement>
         <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
+            <id>releases</id>
+            <url>http://build.mahifx.com/nexus/content/repositories/thirdparty</url>
         </repository>
         <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <id>thirdpartysnapshots</id>
+            <url>http://build.mahifx.com/nexus/content/repositories/thirdpartysnapshots</url>
         </snapshotRepository>
     </distributionManagement>
 
     <repositories>
         <repository>
-            <id>rso</id>
-            <url>http://repository.sonatype.org/content/groups/flexgroup/</url>
+            <id>releases</id>
+            <url>http://build.mahifx.com/nexus/content/repositories/thirdparty</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
         </repository>
     </repositories>
     <pluginRepositories>
         <pluginRepository>
-            <id>rso</id>
-            <url>http://repository.sonatype.org/content/groups/flexgroup/</url>
+            <id>releases</id>
+            <url>http://build.mahifx.com/nexus/content/repositories/thirdparty</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </pluginRepository>
+        <pluginRepository>
+            <id>thirdpartysnapshots</id>
+            <url>http://build.mahifx.com/nexus/content/repositories/thirdpartysnapshots</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
         </pluginRepository>
     </pluginRepositories>
 


### PR DESCRIPTION
We've had several builds fail in the last few days as the default timestamp server (https://services.globaltrustfinder.com/adss/tsa) seems to be having SSL issues. I tried upgrading from flexmojos 7.0.1 to 7.1.1 which didn't help much. So I started looking at the source and realised that option had been removed in the new version of `AirPackager`. Thankfully its an easy API to work with :) 

As Flexmojos 7 requires java 1.8 I've used Optional for specifying the url if you still require to support java 6 I'm happy to re-do the pull request for that.

